### PR TITLE
Add callSite - classLoaderInfo integration

### DIFF
--- a/cmdLine/src/main/scala/topgun/cmdline/ClassLoaderInfo.scala
+++ b/cmdLine/src/main/scala/topgun/cmdline/ClassLoaderInfo.scala
@@ -1,6 +1,8 @@
 package topgun.cmdline
 
 
+import java.io.IOException
+
 import org.objectweb.asm.ClassReader
 import org.objectweb.asm.tree.ClassNode
 
@@ -16,11 +18,13 @@ class ClassLoaderInfo() {
   def buildClassInfo(className: String, classLoader: ClassLoader): ClassInfo = {
     val resourceName = className.replace(".", "/") + ".class"
     val iStream = classLoader.getResourceAsStream(resourceName)
+    if(iStream == null) {
+      return ClassInfo(className,"super not found","sourceFile not found",List())
+    }
     val reader = new ClassReader(iStream)
     val classNode = new ClassNode()
     // specify no parsing options.
-    val parsingFlagNone = 0;
-    reader.accept(classNode, parsingFlagNone)
+    reader.accept(classNode, 0)
     iStream.close()
     val classNameFromReader = reader.getClassName
     val sourceFile = classNode.sourceFile

--- a/cmdLine/src/main/scala/topgun/cmdline/EventTypeIdMapping.scala
+++ b/cmdLine/src/main/scala/topgun/cmdline/EventTypeIdMapping.scala
@@ -2,13 +2,9 @@ package topgun.cmdline
 
 // TODO find reference values inside JMC/JFR and replace with constants.
 //  RecrodedEvent.AllocatedInNewTLAB
-object RecordedEventTypeIdMapping {
+object EventTypeIdMapping {
   val AllocationInNewTLAB = 331
   val AllocationOutsideTlab = 332
   val MethodProfilingSample = 352
   val MethodProfilingSampleNative = 353
-  val RecordingSetting = 2999
-  val OSInformation = 337
-  val InitialSystemProperty = 338
-
 }

--- a/cmdLine/src/main/scala/topgun/cmdline/EventTypeNameMapping.scala
+++ b/cmdLine/src/main/scala/topgun/cmdline/EventTypeNameMapping.scala
@@ -1,0 +1,13 @@
+package topgun.cmdline
+
+// TODO find reference values inside JMC/JFR and replace with constants.
+//  RecrodedEvent.AllocatedInNewTLAB
+object EventTypeNameMapping {
+  val AllocationInNewTLAB = "jdk.ObjectAllocationInNewTLAB"
+  val AllocationOutsideTlab = "jdk.ObjectAllocationOutsideTLAB"
+  val MethodProfilingSample = "jdk.ExecutionSample"
+  val MethodProfilingSampleNative = "jdk.NativeMethodSample"
+  val InitialSystemProperty = "jdk.InitialSystemProperty"
+  val RecordingSetting = "jdk.ActiveSetting"
+  val OSInformation = "jdk.OSInformation"
+}

--- a/cmdLine/src/main/scala/topgun/cmdline/FileParser.scala
+++ b/cmdLine/src/main/scala/topgun/cmdline/FileParser.scala
@@ -16,35 +16,35 @@ class FileParser(file: File, cmdLine: JfrParseCommandLine, totals: Totals, confi
   def parse(): Unit = {
 
     println(s"*** File $file")
-    var classPaths =  new util.ArrayList[URL]
+    var classPaths = new util.ArrayList[URL]
 
     def preProcessing(): String = {
 
-      var FoundAllocationInNewTlabEnabled= false
-      var FoundAllocationOutsideTlabEnabled= false
-      var FoundMethodProfilingSampleEnabled= false
-      var isWindow:Option[Boolean] = None
+      var FoundAllocationInNewTlabEnabled = false
+      var FoundAllocationOutsideTlabEnabled = false
+      var FoundMethodProfilingSampleEnabled = false
+      var isWindow: Option[Boolean] = None
       var classPath = ""
 
       def extractJfrSettings(event: RecordedEvent): Unit = {
 
-        val id:Long = event.getValue("id")
-        val name:String = event.getValue("name")
-        val value:String = event.getValue("value")
+        val id: Long = event.getValue("id")
+        val name: String = event.getValue("name")
+        val value: String = event.getValue("value")
 
-        if( name.equals("enabled") ) {
+        if (name.equals("enabled")) {
           id match {
 
-            case RecordedEventTypeIdMapping.AllocationInNewTLAB =>
-              if(value.toBoolean) FoundAllocationInNewTlabEnabled=true
+            case EventTypeIdMapping.AllocationInNewTLAB =>
+              if (value.toBoolean) FoundAllocationInNewTlabEnabled = true
               else throw new InvalidJfrSettingException(s"failed [file]${file.getName} Reason: 'Allocation in new TLAB' event not enabled")
 
-            case RecordedEventTypeIdMapping.AllocationOutsideTlab =>
-              if(value.toBoolean) FoundAllocationOutsideTlabEnabled=true
+            case EventTypeIdMapping.AllocationOutsideTlab =>
+              if (value.toBoolean) FoundAllocationOutsideTlabEnabled = true
               else throw new InvalidJfrSettingException(s"failed [file]${file.getName} Reason: 'Allocation outside TLAB' event not enabled")
 
-            case RecordedEventTypeIdMapping.MethodProfilingSample =>
-              if(value.toBoolean) FoundMethodProfilingSampleEnabled=true
+            case EventTypeIdMapping.MethodProfilingSample =>
+              if (value.toBoolean) FoundMethodProfilingSampleEnabled = true
               else throw new InvalidJfrSettingException(s"failed [file]${file.getName} Reason: 'Method Profiling Sample' event not enabled")
 
             case _ =>
@@ -52,32 +52,32 @@ class FileParser(file: File, cmdLine: JfrParseCommandLine, totals: Totals, confi
         }
       }
 
-      def notDoneFetchingInfo():Boolean = {
-        !FoundAllocationInNewTlabEnabled ||  !FoundAllocationOutsideTlabEnabled || !FoundMethodProfilingSampleEnabled ||
+      def notDoneFetchingInfo(): Boolean = {
+        !FoundAllocationInNewTlabEnabled || !FoundAllocationOutsideTlabEnabled || !FoundMethodProfilingSampleEnabled ||
           isWindow.isEmpty || classPath.isEmpty
       }
 
       val recordingFile = new RecordingFile(file.toPath)
-      while(recordingFile.hasMoreEvents && notDoneFetchingInfo()){
+      while (recordingFile.hasMoreEvents && notDoneFetchingInfo()) {
         val event = recordingFile.readEvent()
-        event.getEventType.getId match {
+        event.getEventType.getName match {
 
-          case RecordedEventTypeIdMapping.InitialSystemProperty if classPath.isEmpty => if(event.getValue("key").toString.contains("java.class.path"))
+          case EventTypeNameMapping.InitialSystemProperty if classPath.isEmpty => if (event.getValue("key").toString.contains("java.class.path"))
             classPath = event.getValue("value").toString
 
-          case RecordedEventTypeIdMapping.RecordingSetting => extractJfrSettings(event)
+          case EventTypeNameMapping.RecordingSetting => extractJfrSettings(event)
 
-          case RecordedEventTypeIdMapping.OSInformation if isWindow.isEmpty =>
+          case EventTypeNameMapping.OSInformation if isWindow.isEmpty =>
             isWindow = Some(event.getValue("osVersion").toString.toLowerCase.contains("win"))
 
           case _ =>
         }
       }
-      if(notDoneFetchingInfo()){
+      if (notDoneFetchingInfo()) {
         throw new Exception(s"Bad jfrfile [file] ${file}")
       }
       recordingFile.close()
-      ClassLoaderFactory.addIfDoesNotExist(classPath,if (isWindow.get) ";" else ":" )
+      ClassLoaderFactory.addIfDoesNotExist(classPath, if (isWindow.get) ";" else ":")
       classPath
     }
 
@@ -85,13 +85,13 @@ class FileParser(file: File, cmdLine: JfrParseCommandLine, totals: Totals, confi
 
     val recordingFile = new RecordingFile(file.toPath)
 
-    while (recordingFile.hasMoreEvents){
+    while (recordingFile.hasMoreEvents) {
       val event = recordingFile.readEvent()
-      event.getEventType.getLabel match {
-        case "Allocation in new TLAB" => allocation(event, isTLAB = true, classPath)
-        case "Allocation outside TLAB" => allocation(event, isTLAB = false, classPath)
-        case "Method Profiling Sample" => cpu(event, classPath)
-        case "Method Profiling Sample Native" => cpuNative(event, classPath)
+      event.getEventType.getName match {
+        case EventTypeNameMapping.AllocationInNewTLAB => allocation(event, isTLAB = true, classPath)
+        case EventTypeNameMapping.AllocationOutsideTlab => allocation(event, isTLAB = false, classPath)
+        case EventTypeNameMapping.MethodProfilingSample => cpu(event, classPath)
+        case EventTypeNameMapping.MethodProfilingSampleNative => cpuNative(event, classPath)
         case e =>
           totals.ignoreEvent(e)
       }
@@ -109,7 +109,7 @@ class FileParser(file: File, cmdLine: JfrParseCommandLine, totals: Totals, confi
     }
   }
 
-  def allocation(event: RecordedEvent, isTLAB: Boolean, classPath:String): Unit = {
+  def allocation(event: RecordedEvent, isTLAB: Boolean, classPath: String): Unit = {
     val thread = event.getThread
     if ((thread ne null) && !includeThread(thread.getJavaName)) {
       totals.ignoredThreadAllocationEvents.incrementAndGet()
@@ -156,7 +156,7 @@ class FileParser(file: File, cmdLine: JfrParseCommandLine, totals: Totals, confi
     }
   }
 
-  def cpu(event: RecordedEvent, classPath:String): Unit = {
+  def cpu(event: RecordedEvent, classPath: String): Unit = {
     val thread = event.getThread
     if ((thread ne null) && !includeThread(thread.getJavaName)) {
       totals.ignoredThreadCpuEvents.incrementAndGet
@@ -187,12 +187,11 @@ class FileParser(file: File, cmdLine: JfrParseCommandLine, totals: Totals, confi
     }
   }
 
-  def cpuNative(event: RecordedEvent, classPath:String): Unit = {
+  def cpuNative(event: RecordedEvent, classPath: String): Unit = {
     totals.totalEventsNative.incrementAndGet()
     val thread = event.getThread
     if ((thread ne null) && !includeThread(thread.getJavaName)) {
       totals.ignoredThreadCpuEventsNative.incrementAndGet
-
     } else {
       val distinctFrames: List[CallSite] = readFrames(event, classPath)
       if (!includeStack(distinctFrames)) {
@@ -220,26 +219,39 @@ class FileParser(file: File, cmdLine: JfrParseCommandLine, totals: Totals, confi
     }
   }
 
-  private def readFrames(event: RecordedEvent, classPath:String): List[CallSite] = {
+  private def readFrames(event: RecordedEvent, classPath: String): List[CallSite] = {
     val stack = event.getStackTrace
     if (stack eq null) List() else {
       stack.getFrames.iterator.asScala.map {
         frame: RecordedFrame =>
           val method = frame.getMethod
-          if(method ne null) {
+          if (method ne null) {
             val splitIndex = method.getType.getName.lastIndexOf(".")
-            CallSite(
-              method.getType.getName.substring(0,splitIndex).intern(),
-              method.getType.getName.substring(splitIndex+1).intern(),
-              method.getName.intern(),
-              method.getDescriptor.intern(),
-              frame.getLineNumber,
-              classPath.intern()
-            )
+            val packageName = if (splitIndex != -1) method.getType.getName.substring(0, splitIndex).intern() else ""
+            val className = if (splitIndex != -1) method.getType.getName.substring(splitIndex + 1).intern() else method.getType.getName.intern()
+
+            /* The synthetic lambda apply method will call the lambda implementation method with the actual code; that method has line number info.
+            so we should be able to just ignore these "$$Lambda" class frames.
+            map all lambda frames to null and filter out after map*/
+            if (frame.getMethod.isHidden) {
+              null
+            } else {
+              CallSite(
+                packageName,
+                className,
+                method.getName.intern(),
+                method.getDescriptor.intern(),
+                frame.getLineNumber,
+                classPath.intern()
+              )
+            }
           } else {
-            CallSite("NoMethodInFrame_", "NoMethodInFrame_", "NoMethodInFrame_", "NoMethodInFrame_", frame.getLineNumber,classPath.intern())
+            CallSite("NoMethodInFrame_", "NoMethodInFrame_", "NoMethodInFrame_", "NoMethodInFrame_", frame.getLineNumber, classPath.intern())
           }
-      }.distinct.takeWhile { f => !f.isIgnorableTopFrame }.toList
+      }.filter(_ ne null) // $Lambda frames are mapped to null and filtered out.
+        .distinct.takeWhile {
+        !_.isIgnorableTopFrame
+      }.toList
     }
   }
 }


### PR DESCRIPTION
Integration of the classLoaderInfo into CallSite which is now able to lookup sourceFile names. RecordingSetting, OSInformation, InitialSystemProperty removed from the ID mappings due to inconsistencies. The implementation can now handle class names of both types - “com.package.ClassName” as well as “ClassName”.
**NB:** All $$Lambda frames are aggregated as TopGunIgnoredFrame