### PR TITLE
Add source method aggregation

### DIFF
--- a/cmdLine/src/main/scala/topgun/cmdline/AggregateView.java
+++ b/cmdLine/src/main/scala/topgun/cmdline/AggregateView.java
@@ -1,5 +1,6 @@
 package topgun.cmdline;
 
+import scala.Option;
 import topgun.core.CallSite;
 
 public enum AggregateView {
@@ -22,8 +23,25 @@ public enum AggregateView {
                 return CallSite.apply(site.packageName(), site.className(), "", "", maskLineValue, this, site.fileName());
             case PACKAGE_VIEW:
                 return CallSite.apply(site.packageName(), "", "", "", maskLineValue, this, "");
-            case PACKAGE_SOURCE_METHOD_VIEW:
-                return CallSite.apply(site.packageName(), "", site.methodName(), "", maskLineValue, this, site.fileName());
+            case PACKAGE_SOURCE_METHOD_VIEW: {
+                String classSchemaKey = site.packageName() + "." + site.className();
+                if (!site.fileName().contains(site.className()) && site.className().contains("$anon$")) {
+                    try {
+                        classSchemaKey = site.packageName() + "." + site.fileName().substring(0, site.fileName().lastIndexOf('.'));
+                    } catch (StringIndexOutOfBoundsException e) {
+                        classSchemaKey = "";
+                    }
+                }
+                Option<ClassSchema> schemaOption = ClassLoaderFactory.classLoaderInfo().classMethodProfiles().get(classSchemaKey);
+                MethodSchema methodSchema = null;
+
+                if (schemaOption.isDefined()) {
+                    methodSchema = schemaOption.get().getMethodByLine(site.line());
+                }
+                if (methodSchema == null)
+                    return CallSite.apply(site.packageName(), "", "ignore", "ignore", maskLineValue, this, site.fileName());
+                return CallSite.apply(site.packageName(), "", methodSchema.methodName, methodSchema.desc, maskLineValue, this, site.fileName());
+            }
             case PACKAGE_SOURCE_LINE_VIEW:
                 return CallSite.apply(site.packageName(), "", "", "", site.line(), this, site.fileName());
             case PACKAGE_CLASSNAME_METHOD_LINE_VIEW:

--- a/cmdLine/src/main/scala/topgun/cmdline/ClassSchema.java
+++ b/cmdLine/src/main/scala/topgun/cmdline/ClassSchema.java
@@ -1,0 +1,31 @@
+package topgun.cmdline;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public class ClassSchema {
+    public List<MethodSchema> methodSchemaList = new ArrayList<>();
+
+    public void add(MethodSchema methodSchema) {
+        methodSchemaList.add(methodSchema);
+    }
+
+    public void addAll(MethodSchema methodSchema) {
+        methodSchemaList.add(methodSchema);
+    }
+
+    public MethodSchema getMethodByLine(Integer line) {
+
+        var methodList = methodSchemaList.stream().filter(methodSchema -> methodSchema.hasLine(line)).collect(Collectors.toList());
+        if (!methodList.isEmpty())
+            return methodList.get(0);
+        ListIterator<MethodSchema> listIterator = methodSchemaList.listIterator(methodSchemaList.size());
+        while (listIterator.hasPrevious()) {
+            var methodSchema = listIterator.previous();
+            if (methodSchema.firstInstLine < line)
+                return methodSchema;
+        }
+        return null;
+    }
+
+}

--- a/cmdLine/src/main/scala/topgun/cmdline/MethodSchema.java
+++ b/cmdLine/src/main/scala/topgun/cmdline/MethodSchema.java
@@ -1,0 +1,29 @@
+package topgun.cmdline;
+
+public class MethodSchema {
+    public String methodName;
+    public String desc;
+    public Integer firstInstLine;
+    public Integer lastInstLine;
+
+    public MethodSchema(String methodName, String desc, Integer firstInstLine, Integer lastInstLine) {
+        this.methodName = methodName;
+        this.desc = desc;
+        this.firstInstLine = firstInstLine;
+        this.lastInstLine = lastInstLine;
+    }
+
+    public Boolean hasLine(Integer line) {
+        return (line >= firstInstLine) && (line <= lastInstLine);
+    }
+
+    @Override
+    public String toString() {
+        return "MethodSchema{" +
+                "methodName='" + methodName + '\'' +
+                ", desc='" + desc + '\'' +
+                ", firstInstLine=" + firstInstLine +
+                ", lastInstLine=" + lastInstLine +
+                '}';
+    }
+}


### PR DESCRIPTION


We added source-method aggregation. Each frame is matched on to the source file to know which parent methods it belongs to. init and clinit method names are ignored.

[package-source-method-view-ALL.xlsx](https://github.com/mkeskells/TopGun/files/5750308/package-source-method-view-ALL.xlsx)

![screenshot](https://user-images.githubusercontent.com/72229023/103276611-f2242100-49be-11eb-9232-71fb56af1ded.png)
